### PR TITLE
adding HtmlEncode for possibility invalid html markup

### DIFF
--- a/Serilog.Sinks.TelegramBot/StringHelper.cs
+++ b/Serilog.Sinks.TelegramBot/StringHelper.cs
@@ -1,0 +1,12 @@
+﻿using System.Web;
+
+namespace Serilog.Sinks.TelegramBot
+{
+    public static class StringHelper
+    {
+        public static string HtmlEncode(this string htmlStr)
+        {
+            return HttpUtility.HtmlEncode(htmlStr);
+        }
+    }
+}

--- a/Serilog.Sinks.TelegramBot/TelegramSink.cs
+++ b/Serilog.Sinks.TelegramBot/TelegramSink.cs
@@ -65,17 +65,22 @@ namespace Serilog.Sinks.TelegramBot
         protected static TelegramMessage RenderMessage(LogEvent logEvent)
         {
             var sb = new StringBuilder();
-            sb.AppendLine(value: $"{GetEmoji(log: logEvent)} {logEvent.RenderMessage()}");
+            if (_parseMode == ParseMode.Markdown)
+                sb.AppendLine(value: $"{GetEmoji(log: logEvent)} {logEvent.RenderMessage()}");
+            else
+                sb.AppendLine(value: $"{GetEmoji(log: logEvent)} {logEvent.RenderMessage().HtmlEncode()}");
 
             if (!string.IsNullOrEmpty(_applicationName))
             {
-                sb.AppendLine(value: _parseMode == ParseMode.Markdown 
-                    ? $"🤖 App: `{_applicationName}`" 
-                    : $"🤖 App: <code>{_applicationName}</code>");
+                sb.AppendLine(
+                    value: _parseMode == ParseMode.Markdown
+                        ? $"🤖 App: `{_applicationName}`"
+                        : $"🤖 App: <code>{_applicationName.HtmlEncode()}</code>"
+                );
             }
 
             if (logEvent.Exception == null) return new TelegramMessage(text: sb.ToString());
-            
+
             if (_parseMode == ParseMode.Markdown)
             {
                 sb.AppendLine(value: $"\n*{logEvent.Exception.Message}*\n");
@@ -85,12 +90,12 @@ namespace Serilog.Sinks.TelegramBot
             }
             else
             {
-                sb.AppendLine(value: $"\n<b>{logEvent.Exception.Message}</b>\n");
-                sb.AppendLine(value: $"Message: <code>{logEvent.Exception.Message}</code>");
+                sb.AppendLine(value: $"\n<b>{logEvent.Exception.Message.HtmlEncode()}</b>\n");
+                sb.AppendLine(value: $"Message: <code>{logEvent.Exception.Message.HtmlEncode()}</code>");
                 sb.AppendLine(value: $"Type: <code>{logEvent.Exception.GetType().Name}</code>\n");
-                sb.AppendLine(value: $"Stack Trace\n<code>{logEvent.Exception}</code>");
+                sb.AppendLine(value: $"Stack Trace\n<code>{logEvent.Exception.ToString().HtmlEncode()}</code>");
             }
-            
+
             return new TelegramMessage(text: sb.ToString());
         }
 


### PR DESCRIPTION
Sometimes exception string contains like invalid html tag, e.g `List<string>` or `List<SomeObject>`, it's like unclosed markup for HTML. 
it's causing this sink stop working because ParseMode.HTML is fail.

With this PR, this problem will be fixed

I have a create simple test for this, like an image below.

![image](https://user-images.githubusercontent.com/17938038/173076813-a4da7973-4a56-4dc2-9086-7e8eb04b4cbf.png)
